### PR TITLE
Changed references to doc to docs in OneRingApi Specs

### DIFF
--- a/samples/theoneapi-simple.yaml
+++ b/samples/theoneapi-simple.yaml
@@ -63,7 +63,7 @@ components:
     PagedBooks:
       type: object
       properties:
-        doc:
+        docs:
           type: array
           items:
             $ref: '#/components/schemas/Book'

--- a/samples/theoneapi.yaml
+++ b/samples/theoneapi.yaml
@@ -416,7 +416,7 @@ components:
     Books:
       type: object
       properties:
-        doc:
+        docs:
           type: array
           items:
             $ref: "#/components/schemas/Book"
@@ -434,7 +434,7 @@ components:
     Movies:
       type: object
       properties:
-        doc:
+        docs:
           type: array
           items:
             $ref: "#/components/schemas/Movie"
@@ -452,7 +452,7 @@ components:
     Chapters:
       type: object
       properties:
-        doc:
+        docs:
           type: array
           items:
             $ref: "#/components/schemas/Chapter"
@@ -470,7 +470,7 @@ components:
     Characters:
       type: object
       properties:
-        doc:
+        docs:
           type: array
           items:
             $ref: "#/components/schemas/Character"
@@ -488,7 +488,7 @@ components:
     Quotes:
       type: object
       properties:
-        doc:
+        docs:
           type: array
           items:
             $ref: "#/components/schemas/Quote"


### PR DESCRIPTION
The spec files we currently had described certain endpoints of returning a property called `doc` but the real API responds with a property called `docs`.

Actual Response:
```json
{
    "docs": [
        {
            "_id": "5cd95395de30eff6ebccde56",
            "name": "The Lord of the Rings Series",
            "runtimeInMinutes": 558,
            "budgetInMillions": 281,
            "boxOfficeRevenueInMillions": 2917,
            "academyAwardNominations": 30,
            "academyAwardWins": 17,
            "rottenTomatoesScore": 94
        },
        {
            "_id": "5cd95395de30eff6ebccde57",
            "name": "The Hobbit Series",
            "runtimeInMinutes": 462,
            "budgetInMillions": 675,
            "boxOfficeRevenueInMillions": 2932,
            "academyAwardNominations": 7,
            "academyAwardWins": 1,
            "rottenTomatoesScore": 66.33333333
        },
        ...
    ],
    "total": 8,
    "limit": 1000,
    "offset": 0,
    "page": 1,
    "pages": 1
}
```